### PR TITLE
Fix fetching all regions

### DIFF
--- a/assets/js/user/redux.js
+++ b/assets/js/user/redux.js
@@ -334,7 +334,7 @@ export const fetchAllRegions = () => {
     return async (dispatch) => {
         dispatch(getAllRegions())
         try {
-            const response = await profileRequest.get(`/geo-division/?limit=200/`)
+            const response = await profileRequest.get(`/geo-division/?limit=200`)
             dispatch(getAllRegionsSuccess(response.data))
         } catch (error) {
             dispatch(getAllRegionsError(error))


### PR DESCRIPTION
Slash after get parameters cancels them out. Remove the slash to
actually apply the limit of 200 results to avoid API pagination.