### PR TITLE
no-unused-vars warning instead of error

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -9,7 +9,8 @@
   "rules": {
     "no-console": "warn",
     "space-infix-ops": "error",
-    "prettier/prettier": "error"
+    "prettier/prettier": "error",
+    "no-unused-vars": "warn"
   },
   "plugins": ["prettier"]
 }


### PR DESCRIPTION
Should probably have different configs for development/production
> Do this for now in the name of developer experience ;) 